### PR TITLE
ci: Remove renovate trigger on issue change

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -4,8 +4,6 @@ on:
   schedule:
     - cron: '0 3 * * *'  # Run once per day at 03:00 UTC
   workflow_dispatch:
-  issues:
-    types: [edited]  # Trigger when checkboxes are checked in the Dependency Dashboard
 
 concurrency:
   group: renovate
@@ -14,9 +12,6 @@ concurrency:
 jobs:
   renovate:
     runs-on: ubuntu-latest
-    if: >-
-      github.event_name != 'issues' ||
-      github.event.issue.title == 'Dependency Dashboard'
     steps:
       - name: Checkout
         uses: actions/checkout@v7


### PR DESCRIPTION
The trigger is too general and also causes a retrigger when the workflow itself modifies the issue.